### PR TITLE
Adds Dark Mode Component Button

### DIFF
--- a/web/component_library/README.md
+++ b/web/component_library/README.md
@@ -21,3 +21,19 @@ pnpm dev
 # or
 bun dev
 ```
+
+## Dark Mode Component
+
+The Dark Mode component uses a context that wraps the entire application. Its basic functionality is to toggle the `dark` class on the document elements.
+
+Elements with the `dark` class added in Tailwind CSS will be affected when the Dark Mode toggle button is clicked. This allows for a seamless transition between light and dark themes in your application.
+
+### How to Use
+
+1. Wrap your entire application with the Dark Mode context.
+2. Add the `dark` class to any elements in your application that you want to be affected by Dark Mode.
+3. Use the Dark Mode toggle button to switch between themes.
+
+Enjoy coding in the dark!
+
+

--- a/web/component_library/app/Contexts/DarkModeContext.js
+++ b/web/component_library/app/Contexts/DarkModeContext.js
@@ -1,0 +1,6 @@
+'use client'
+import { createContext } from "react"
+
+const DarkModeContext = createContext();
+
+export default DarkModeContext;

--- a/web/component_library/app/Contexts/DarkmodeState.jsx
+++ b/web/component_library/app/Contexts/DarkmodeState.jsx
@@ -1,0 +1,12 @@
+'use client'
+import React, { useState } from 'react'
+import DarkModeContext from './DarkModeContext';
+export default function DarkmodeState(props) {
+    const [darkMode,setDarkMode]=useState(localStorage.getItem("dark"));
+
+  return (
+    <DarkModeContext.Provider value={{darkMode,setDarkMode}}>
+        { props.children }
+    </DarkModeContext.Provider>
+  )
+}

--- a/web/component_library/app/components/DrakModeButton.jsx
+++ b/web/component_library/app/components/DrakModeButton.jsx
@@ -1,0 +1,44 @@
+'use client'
+import React, { useContext, useEffect } from 'react'
+import DarkModeContext from '../Contexts/DarkModeContext';
+
+export default function DarkMode() {
+    const darkmodeToggler = useContext(DarkModeContext)
+
+    function toggleDarkMode() {
+        document.documentElement.classList.toggle('dark');
+        darkmodeToggler.setDarkMode(document.documentElement.classList.contains("dark"));
+        if (document.documentElement.classList.contains("dark")) {
+            localStorage.setItem("dark", "true");
+        } else {
+            localStorage.removeItem("dark");
+        }
+    }
+    useEffect(()=>{
+        const darkMode = localStorage.getItem("dark");
+        if (darkMode) {
+            document.documentElement.classList.add("dark");
+        } else {
+            document.documentElement.classList.remove("dark");
+        }
+    },[])
+    return (
+        <div className='flex justify-center items-center'>
+            <button type="button" id="headlessui-listbox-button-:R19kcr6:" aria-haspopup="true" aria-expanded="false" data-headlessui-state="" aria-labelledby="headlessui-listbox-label-:Rpkcr6: headlessui-listbox-button-:R19kcr6:" onClick={toggleDarkMode}>
+                <span class="hidden dark:inline">
+                    <svg viewBox="0 0 24 24" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6">
+                        <path d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" class="fill-sky-400/20 stroke-sky-500"></path>
+                        <path d="M12 4v1M17.66 6.344l-.828.828M20.005 12.004h-1M17.66 17.664l-.828-.828M12 20.01V19M6.34 17.664l.835-.836M3.995 12.004h1.01M6 6l.835.836" class="stroke-sky-500"></path>
+                    </svg>
+                </span>
+                <span class="dark:hidden">
+                    <svg viewBox="0 0 24 24" fill="none" class="w-6 h-6">
+                        <path fill-rule="evenodd" clip-rule="evenodd" d="M17.715 15.15A6.5 6.5 0 0 1 9 6.035C6.106 6.922 4 9.645 4 12.867c0 3.94 3.153 7.136 7.042 7.136 3.101 0 5.734-2.032 6.673-4.853Z" class="fill-sky-400/20"></path>
+                        <path d="m17.715 15.15.95.316a1 1 0 0 0-1.445-1.185l.495.869ZM9 6.035l.846.534a1 1 0 0 0-1.14-1.49L9 6.035Zm8.221 8.246a5.47 5.47 0 0 1-2.72.718v2a7.47 7.47 0 0 0 3.71-.98l-.99-1.738Zm-2.72.718A5.5 5.5 0 0 1 9 9.5H7a7.5 7.5 0 0 0 7.5 7.5v-2ZM9 9.5c0-1.079.31-2.082.845-2.93L8.153 5.5A7.47 7.47 0 0 0 7 9.5h2Zm-4 3.368C5 10.089 6.815 7.75 9.292 6.99L8.706 5.08C5.397 6.094 3 9.201 3 12.867h2Zm6.042 6.136C7.718 19.003 5 16.268 5 12.867H3c0 4.48 3.588 8.136 8.042 8.136v-2Zm5.725-4.17c-.81 2.433-3.074 4.17-5.725 4.17v2c3.552 0 6.553-2.327 7.622-5.537l-1.897-.632Z" class="fill-sky-500"></path>
+                        <path fill-rule="evenodd" clip-rule="evenodd" d="M17 3a1 1 0 0 1 1 1 2 2 0 0 0 2 2 1 1 0 1 1 0 2 2 2 0 0 0-2 2 1 1 0 1 1-2 0 2 2 0 0 0-2-2 1 1 0 1 1 0-2 2 2 0 0 0 2-2 1 1 0 0 1 1-1Z" class="fill-sky-500"></path>
+                    </svg>
+                </span>
+            </button>
+        </div>
+    )
+}

--- a/web/component_library/app/components/Footer.jsx
+++ b/web/component_library/app/components/Footer.jsx
@@ -86,7 +86,7 @@ export default function Footer() {
         }
     ]
     return (
-        <footer className="pt-10 bg-gray-800">
+        <footer className="pt-10 bg-gray-700 dark:bg-gray-800">
             <div className="max-w-screen-xl mx-auto px-4 md:px-8">
                 <div className="justify-between items-center gap-12 md:flex">
                     <div className="flex-1 max-w-lg">

--- a/web/component_library/app/components/Hero.jsx
+++ b/web/component_library/app/components/Hero.jsx
@@ -1,5 +1,6 @@
 'use client'
 import { useState, useEffect } from "react";
+import DarkMode from "./DrakModeButton";
 
 export default function Hero () {
 
@@ -60,6 +61,7 @@ export default function Hero () {
                 <nav className={`pb-5 md:text-sm ${state ? "absolute z-20 top-0 inset-x-0 bg-gray-800 rounded-xl mx-2 mt-2 md:mx-0 md:mt-0 md:relative md:bg-transparent" : ""}`}>
                     <div className="gap-x-14 items-center max-w-screen-xl mx-auto px-4 md:flex md:px-8">
                         <Brand />
+                        <DarkMode/>
                         <div className={`flex-1 items-center mt-8 md:mt-0 md:flex ${state ? 'block' : 'hidden'} `}>
                             <ul className="flex-1 justify-end items-center space-y-6 md:flex md:space-x-6 md:space-y-0">
                                 {

--- a/web/component_library/app/layout.js
+++ b/web/component_library/app/layout.js
@@ -1,3 +1,4 @@
+import DarkmodeState from './Contexts/DarkmodeState'
 import './globals.css'
 import { Inter } from 'next/font/google'
 
@@ -11,7 +12,9 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
+    <DarkmodeState>
       <body className={inter.className}>{children}</body>
+    </DarkmodeState>
     </html>
   )
 }

--- a/web/component_library/tailwind.config.js
+++ b/web/component_library/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
     './components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Issue 
Fixes #176 

## Description
In this issue, I have made a dark mode button which allows users to switch between light and dark themes.

## Changes Made
- Added a new button for toggling between light and dark modes which preserves the state of previous mode in Local Storage.
- Implemented context to manage the state of the theme across the application.
- Used Tailwind CSS to style the dark mode elements.

## How to Test
1. Pull down this branch.
2. Start the application.
3. Click on the Dark Mode button to switch between themes.

## Screenshots
Light mode -- 
![image](https://github.com/tenzopy/codeIt/assets/119877487/471c0e89-b10a-4878-9b3d-5e615b9ab6ca)

Dark Mode -- 
![image](https://github.com/tenzopy/codeIt/assets/119877487/25910780-7473-4463-92dd-679cbb2665bb)

### NOTE -- 
**Just for the sample I have added the dark class to the footer (there is the slight difference in color in the footer) it is not the actual one, developer can manage the dark class into the footer as per their need**

Please review and provide your feedback. Thank you!